### PR TITLE
Expose the Latex PDF exporter

### DIFF
--- a/hide_code/Templates/hide_code.tpl
+++ b/hide_code/Templates/hide_code.tpl
@@ -26,9 +26,6 @@ div.output_subarea {
 {%- endblock in_prompt -%}
 
 {% block output %}
-{%- if cell.metadata.hideOutput -%}
-<div class="output_area"></div>
-{%- else -%}
 <div class="output_area">
 	{%- if output.output_type == 'execute_result' and not cell.metadata.hidePrompt -%}
 	    <div class="prompt output_prompt">
@@ -41,11 +38,13 @@ div.output_subarea {
 	    <div class="prompt">
 	{%- endif -%}
 	</div>
-	{% block execute_result -%}	{{ super() }} {%- endblock execute_result %}
-	{%- block stream -%} {{ super() }} {%- endblock stream -%}
-	{%- if output.output_type == 'error' -%}
-		{%- block error -%} {{ super() }} {%- endblock error -%}
-	{%- endif -%}
+	{%- if cell.metadata.hideOutput -%}
+  {%- else -%}
+	    {% block execute_result -%}	{{ super() }} {%- endblock execute_result %}
+	    {%- block stream -%} {{ super() }} {%- endblock stream -%}
+	    {%- if output.output_type == 'error' -%}
+		      {%- block error -%} {{ super() }} {%- endblock error -%}
+	    {%- endif -%}
+  {%- endif -%}
 </div>
-{%- endif -%}
 {% endblock output %}

--- a/hide_code/Templates/hide_code_base_style.tplx
+++ b/hide_code/Templates/hide_code_base_style.tplx
@@ -20,7 +20,7 @@
 %===============================================================================
 
 ((* block input scoped *))
-    ((( add_prompt(cell.source | highlight_code(strip_verbatim=True), cell, 'In ', 'incolor') )))
+    ((( add_prompt(cell.source | highlight_code(strip_verbatim=True), cell, 'In ', 'incolor', cell.metadata.hideCode) )))
 ((* endblock input *))
 
 
@@ -31,7 +31,7 @@
 ((* block execute_result scoped *))
     ((*- for type in output.data | filter_data_type -*))
         ((*- if type in ['text/plain']*))
-            ((( add_prompt(output.data['text/plain'] | escape_latex, cell, 'Out', 'outcolor') )))
+            ((( add_prompt(output.data['text/plain'] | escape_latex, cell, 'Out', 'outcolor', False) )))
         ((* else -*))
 \texttt{\color{outcolor}Out[{\color{outcolor}((( cell.execution_count )))}]:}((( super() )))
         ((*- endif -*))
@@ -43,28 +43,22 @@
 % Support Macros
 %==============================================================================
 
-% Name: draw_prompt
+% Name: add_prompt
 % Purpose: Renders an output/input prompt
-((* macro add_prompt(text, cell, prompt, prompt_color) -*))
+((* macro add_prompt(text, cell, prompt, prompt_color, hide_contents=False) -*))
     ((*- if cell.execution_count is defined -*))
-    ((*- set execution_count = "" ~ (cell.execution_count | replace(None, " ")) -*))
+        ((*- set execution_count = "" ~ (cell.execution_count | replace(None, " ")) -*))
     ((*- else -*))
-    ((*- set execution_count = " " -*))
+        ((*- set execution_count = " " -*))
     ((*- endif -*))
     ((*- set indention =  " " * (execution_count | length + 7) -*))
+    ((*- if hide_contents -*))
+        ((*- set text = "" -*))
+    ((*- endif -*))
 
-((*- if cell.metadata.hidePrompt and cell.metadata.hideCode-*))
-\begin{Verbatim}[commandchars=\\\{\}]
-
-\end{Verbatim}
-((*- elif cell.metadata.hidePrompt -*))
+((*- if cell.metadata.hidePrompt -*))
 \begin{Verbatim}[commandchars=\\\{\}]
 ((( text )))
-\end{Verbatim}
-((*- elif cell.metadata.hideCode -*))
-((*- set text = "" -*))
-\begin{Verbatim}[commandchars=\\\{\}]
-((( text | add_prompts(first='{\color{' ~ prompt_color ~ '}' ~ prompt ~ '[{\\color{' ~ prompt_color ~ '}' ~ execution_count ~ '}]:} ', cont=indention) )))
 \end{Verbatim}
 ((*- else -*))
 \begin{Verbatim}[commandchars=\\\{\}]

--- a/hide_code/Templates/hide_code_base_style.tplx
+++ b/hide_code/Templates/hide_code_base_style.tplx
@@ -43,13 +43,19 @@
     ((*- endfor -*))
 ((* endblock execute_result *))
 
-
 ((* block stream *))
 ((*- if cell.metadata.hideOutput -*))
 ((*- else -*))
     ((( super() )))
 ((*- endif -*))
 ((* endblock stream *))
+
+((* block error *))
+((*- if cell.metadata.hideOutput -*))
+((*- else -*))
+    ((( super() )))
+((*- endif -*))
+((* endblock error *))
 
 %==============================================================================
 % Support Macros

--- a/hide_code/Templates/hide_code_base_style.tplx
+++ b/hide_code/Templates/hide_code_base_style.tplx
@@ -29,16 +29,18 @@
 %===============================================================================
 
 ((* block execute_result scoped *))
-((*- if cell.metadata.hideOutput -*))
-((*- else -*))
     ((*- for type in output.data | filter_data_type -*))
         ((*- if type in ['text/plain'] -*))
-            ((( add_prompt(output.data['text/plain'] | escape_latex, cell, 'Out', 'outcolor') )))
+            ((( add_prompt(output.data['text/plain'] | escape_latex, cell, 'Out', 'outcolor', cell.metadata.hideOutput) )))
         ((*- else -*))
-\texttt{\color{outcolor}Out[{\color{outcolor}((( cell.execution_count )))}]:}((( super() )))
+            ((*- if cell.metadata.hidePrompt -*))
+\texttt{\color{outcolor}Out[{\color{outcolor}((( cell.execution_count )))}]:}
+            ((*- endif -*))
+            ((*- if cell.metadata.hideOutput -*))
+((( super() )))
+            ((*- endif -*))
         ((*- endif -*))
     ((*- endfor -*))
-((*- endif -*))
 ((* endblock execute_result *))
 
 

--- a/hide_code/hide_code.js
+++ b/hide_code/hide_code.js
@@ -105,7 +105,7 @@ function ($, celltoolbar){
 		    },
 		    {
 		    	'label' : 'Export to PDF via Latex',
-		    	'icon' : 'fa-file-pdf-o',
+		    	'icon' : 'fa-file-o',
 		    	'callback' : function (){
 		    		window.location=document.URL + "/export/latexpdf"
 		    	}

--- a/hide_code/hide_code.js
+++ b/hide_code/hide_code.js
@@ -74,9 +74,9 @@ function ($, celltoolbar){
 	function toggleHideOutput(cell){
 		var c = $(cell.element);
 		if (cell.metadata.hideOutput && cell.class_config.classname != 'MarkdownCell'){
-			c.find('.output_wrapper').css('display','none');
+			c.find('.output_wrapper .output_subarea').css('display','none');
 		} else if(cell.class_config.classname != 'MarkdownCell') {
-			c.find('.output_wrapper').css('display','flex'); 
+			c.find('.output_wrapper .output_subarea').css('display','block'); 
 		}
 	}
 


### PR DESCRIPTION
I was looking to add code and prompt hiding to the Latex PDF output included with Jupyter Notebook. Your extension does this nicely, but for some reason doesn't expose the functionality. I've found that the Latex output is a bit nicer than the HTML based output for my uses. It doesn't break pages in the middle of images leaving half of the image on each page as can happen with the HTML based PDF output.