### PR TITLE
Enable hiding of outputs

### DIFF
--- a/hide_code/Templates/hide_code.tpl
+++ b/hide_code/Templates/hide_code.tpl
@@ -26,6 +26,9 @@ div.output_subarea {
 {%- endblock in_prompt -%}
 
 {% block output %}
+{%- if cell.metadata.hideOutput -%}
+<div class="output_area"></div>
+{%- else -%}
 <div class="output_area">
 	{%- if output.output_type == 'execute_result' and not cell.metadata.hidePrompt -%}
 	    <div class="prompt output_prompt">
@@ -42,4 +45,5 @@ div.output_subarea {
 	{%- block stream -%} {{ super() }} {%- endblock stream -%}
 	{%- block error -%} {{ super() }} {%- endblock error -%}
 </div>
+{%- endif -%}
 {% endblock output %}

--- a/hide_code/Templates/hide_code_base_style.tplx
+++ b/hide_code/Templates/hide_code_base_style.tplx
@@ -29,15 +29,25 @@
 %===============================================================================
 
 ((* block execute_result scoped *))
+((*- if cell.metadata.hideOutput -*))
+((*- else -*))
     ((*- for type in output.data | filter_data_type -*))
-        ((*- if type in ['text/plain']*))
+        ((*- if type in ['text/plain'] -*))
             ((( add_prompt(output.data['text/plain'] | escape_latex, cell, 'Out', 'outcolor') )))
-        ((* else -*))
+        ((*- else -*))
 \texttt{\color{outcolor}Out[{\color{outcolor}((( cell.execution_count )))}]:}((( super() )))
         ((*- endif -*))
     ((*- endfor -*))
+((*- endif -*))
 ((* endblock execute_result *))
 
+
+((* block stream *))
+((*- if cell.metadata.hideOutput -*))
+((*- else -*))
+    ((( super() )))
+((*- endif -*))
+((* endblock stream *))
 
 %==============================================================================
 % Support Macros
@@ -53,7 +63,7 @@
     ((*- endif -*))
     ((*- set indention =  " " * (execution_count | length + 7) -*))
 
-((*- if cell.metadata.hidePrompt and cell.metadata.hideCode-*))
+((*- if cell.metadata.hidePrompt and cell.metadata.hideCode -*))
 \begin{Verbatim}[commandchars=\\\{\}]
 
 \end{Verbatim}

--- a/hide_code/hide_code.js
+++ b/hide_code/hide_code.js
@@ -41,6 +41,18 @@ function ($, celltoolbar){
 		return (isHidden == undefined) ? undefined : isHidden
 	}
 
+	function hideOutputSetter(cell, value){
+		if (cell.metadata.hideOutput == undefined){ cell.metadata.hideOutput = false }
+        cell.metadata.hideOutput = value;
+   		toggleHideOutput(cell);
+	}
+
+	function hideOutputGetter(cell){
+		var isHidden = cell.metadata.hideOutput;
+		toggleHideOutput(cell);
+		return (isHidden == undefined) ? undefined : isHidden
+	}
+
 	function toggleHideCode(cell){
 		var c = $(cell.element);
 		if (cell.metadata.hideCode && cell.class_config.classname != 'MarkdownCell'){
@@ -59,6 +71,15 @@ function ($, celltoolbar){
 		}
 	}
 
+	function toggleHideOutput(cell){
+		var c = $(cell.element);
+		if (cell.metadata.hideOutput && cell.class_config.classname != 'MarkdownCell'){
+			c.find('.output_wrapper').css('display','none');
+		} else if(cell.class_config.classname != 'MarkdownCell') {
+			c.find('.output_wrapper').css('display','flex'); 
+		}
+	}
+
 	/**
 	* Add a toolbar button to toggle visibility of all code cells, input/output prompts, and remove any highlighting for the selected cell.
 	**/
@@ -67,7 +88,7 @@ function ($, celltoolbar){
 		    {
 		     'label' : 'Hide/show code',
 		     'icon' : 'fa-code',
-		     'callback' : function() { // toggling visibility is adding display: blcok to the element. Causing celltoolbar = None not work.
+		     'callback' : function() { // toggling visibility is adding display: block to the element. Causing celltoolbar = None not work.
 		        $('.input').toggle(); 
 		        $('.prompt').toggle(); 
 		        var ctb = $('.ctb_hideshow');
@@ -110,14 +131,18 @@ function ($, celltoolbar){
 
 	var hidePromptCallback = ctb.utils.checkbox_ui_generator('Hide Prompts ', hidePromptSetter,	hidePromptGetter);
 
+	var hideOutputCallback = ctb.utils.checkbox_ui_generator('Hide Outputs ', hideOutputSetter,	hideOutputGetter);
+
 	function setup(){
 		ctb.register_callback('hide_code.hideCode', hideCodeCallback);
         ctb.register_callback('hide_code.hidePrompts', hidePromptCallback);
-        ctb.register_preset('Hide code',['hide_code.hidePrompts','hide_code.hideCode']);
+        ctb.register_callback('hide_code.hideOutputs', hideOutputCallback);
+        ctb.register_preset('Hide code',['hide_code.hidePrompts','hide_code.hideCode','hide_code.hideOutputs']);
         addHideCodeButtonToToolbar();
         $.each(Jupyter.notebook.get_cells(), function(index, cell){
         	toggleHidePrompt(cell);
         	toggleHideCode(cell);
+        	toggleHideOutput(cell);
         });
 	}
 	


### PR DESCRIPTION
This patch adds a third checkbox in the cell toolbar. I used it to hide output streams. Please give the code a quick lookover. I'm not familiar with Jinja2 templates.