### PR TITLE
Added viewing output.text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ hide_code.sublime-project
 hide_code.sublime-workspace
 /hide_code/test/*.ipynb
 /hide_code/test/.ipynb_checkpoints/*
+*.iml
+*.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: python
 python:
   - "2.7"
-  - "3.3"
+# Building 3.3 fails;
+# ImportError: Tornado requires an up-to-date SSL module. This means Python 2.7.9+ or 3.4+ (although some distributions
+# have backported the necessary changes to older versions).
+#  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"
@@ -16,7 +19,7 @@ install:
   - pip install pdfkit
   - pip install -e .
 # command to run tests
-script: 
+script:
   - jupyter nbextension install --py hide_code --sys-prefix
   - jupyter nbextension enable --py hide_code --sys-prefix
   - jupyter serverextension enable --py hide_code --sys-prefix

--- a/hide_code/Templates/hide_code_full.tpl
+++ b/hide_code/Templates/hide_code_full.tpl
@@ -51,7 +51,7 @@
             {% block error %} {{ super() }} {% endblock error %}
         {%- endif -%}
     {%- elif output.text -%}
-        {{ super() }}
+		{% block stream_stdout -%} {{ super() }} {% endblock stream_stdout -%}
     {%- endif -%}
 {%- endif -%}
 </div>

--- a/hide_code/Templates/hide_code_full.tpl
+++ b/hide_code/Templates/hide_code_full.tpl
@@ -1,32 +1,32 @@
 {%- extends 'full.tpl' -%}
 
 {%-block html_head-%}
-<style type="text/css">
-div.output_subarea {
-	max-width: 100% !important;
-}
-</style>
-{{ super() }}
+    <style type="text/css">
+        div.output_subarea {
+            max-width: 100% !important;
+        }
+    </style>
+    {{ super() }}
 {%- endblock html_head -%}
 
 {%- block input -%}
-	{%- if cell.metadata.hideCode -%}
-		<div></div>
-	{%- else -%}
-		{{ super() }}
-	{%- endif -%}
+    {%- if cell.metadata.hideCode -%}
+        <div></div>
+    {%- else -%}
+        {{ super() }}
+    {%- endif -%}
 {%- endblock input -%}
 
 {%- block in_prompt -%}
-	{%- if cell.metadata.hidePrompt -%}
-		<div class="prompt input_prompt"></div>
-	{%- else -%}
-		{{ super() }}
-	{%- endif -%}
+    {%- if cell.metadata.hidePrompt -%}
+        <div class="prompt input_prompt"></div>
+    {%- else -%}
+        {{ super() }}
+    {%- endif -%}
 {%- endblock in_prompt -%}
 
 {% block output %}
-<div class="output_area">
+    <div class="output_area">
     {% if resources.global_content_filter.include_output_prompt %}
         {% block output_area_prompt %}
             {%- if output.output_type == 'execute_result' and not cell.metadata.hidePrompt -%}
@@ -41,16 +41,18 @@ div.output_subarea {
             {%- endif -%}
         </div>
         {% endblock output_area_prompt %}
-	{% endif %}
-	{%- if cell.metadata.hideOutput -%}
-    {%- else -%}
-        {% if output.data %}
-            {% block execute_result -%}	{{ super() }} {% endblock execute_result %}
-            {% block stream -%} {{ super() }} {% endblock stream -%}
-            {%- if output.output_type == 'error' -%}
-                  {% block error %} {{ super() }} {% endblock error %}
-            {%- endif -%}
-        {% endif %}
+    {% endif %}
+{%- if cell.metadata.hideOutput -%}
+{%- else -%}
+    {% if output.data %}
+        {% block execute_result -%}	{{ super() }} {% endblock execute_result %}
+        {% block stream -%} {{ super() }} {% endblock stream -%}
+        {%- if output.output_type == 'error' -%}
+            {% block error %} {{ super() }} {% endblock error %}
+        {%- endif -%}
+    {%- elif output.text -%}
+        {{ super() }}
     {%- endif -%}
+{%- endif -%}
 </div>
 {% endblock output %}


### PR DESCRIPTION
When executing 'behave' cell magic in a notebook, behave prints output
to standard out. (http://behave.readthedocs.io/en/latest/tutorial.html)

Example output:
"""
    Feature: showing off behave # features/tutorial.feature:1

      Scenario: run a simple test        # features/tutorial.feature:3
        Given we have behave installed   # features/steps/tutorial.py:3
        When we implement a test         # features/steps/tutorial.py:7
        Then behave will test it for us! # features/steps/tutorial.py:11

    1 feature passed, 0 failed, 0 skipped
    1 scenario passed, 0 failed, 0 skipped
    3 steps passed, 0 failed, 0 skipped, 0 undefined
"""

Issue:
    Even when no hide checkbox is selected, I don't see standard output back in the html file.

Fix:
    I have added a Jinja elif for json key output.text; it just shows everything inside the json value.

Perhaps the filter logic could be better, but I am not that familiar with notebook output options.
IE; are data and text mutually exclusive?
Or are there even more types, which might warrant an {%- else -%}{{super()}}?